### PR TITLE
Extracting the actual address the host was bound to

### DIFF
--- a/host.c
+++ b/host.c
@@ -31,6 +31,7 @@ enet_host_create (const ENetAddress * address, size_t peerCount, size_t channelL
 {
     ENetHost * host;
     ENetPeer * currentPeer;
+    ENetAddress actualAddress;
 
     if (peerCount > ENET_PROTOCOL_MAXIMUM_PEER_ID)
       return NULL;
@@ -66,7 +67,9 @@ enet_host_create (const ENetAddress * address, size_t peerCount, size_t channelL
     enet_socket_set_option (host -> socket, ENET_SOCKOPT_RCVBUF, ENET_HOST_RECEIVE_BUFFER_SIZE);
     enet_socket_set_option (host -> socket, ENET_SOCKOPT_SNDBUF, ENET_HOST_SEND_BUFFER_SIZE);
 
-    if (address != NULL)
+    if (enet_socket_get_address (host -> socket, & actualAddress) == 0)
+      host -> address = actualAddress;
+    else if (address != NULL)
       host -> address = * address;
 
     if (! channelLimit || channelLimit > ENET_PROTOCOL_MAXIMUM_CHANNEL_COUNT)

--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -478,6 +478,7 @@ ENET_API int        enet_socket_send (ENetSocket, const ENetAddress *, const ENe
 ENET_API int        enet_socket_receive (ENetSocket, ENetAddress *, ENetBuffer *, size_t);
 ENET_API int        enet_socket_wait (ENetSocket, enet_uint32 *, enet_uint32);
 ENET_API int        enet_socket_set_option (ENetSocket, ENetSocketOption, int);
+ENET_API int        enet_socket_get_address (ENetSocket, ENetAddress *);
 ENET_API int        enet_socket_shutdown (ENetSocket, ENetSocketShutdown);
 ENET_API void       enet_socket_destroy (ENetSocket);
 ENET_API int        enet_socketset_select (ENetSocket, ENetSocketSet *, ENetSocketSet *, enet_uint32);

--- a/unix.c
+++ b/unix.c
@@ -291,6 +291,24 @@ enet_socket_accept (ENetSocket socket, ENetAddress * address)
 
     return result;
 } 
+
+int
+enet_socket_get_address (ENetSocket socket, ENetAddress * address)
+{
+    // We're allocating only enough memory for an IPv4 address as IPv6 is
+    // currently unsupported. If socket were bound to an IPv6 address
+    // getsockname() would fail and enet_socket_get_address() would return -1.
+    struct sockaddr_in socket_address;
+    socklen_t socket_address_length = sizeof(struct sockaddr_in);
+
+    if (getsockname (socket, (struct sockaddr *) & socket_address, & socket_address_length) != 0)
+      return -1;
+
+    address->host = socket_address.sin_addr.s_addr;
+    address->port = socket_address.sin_port;
+
+    return 0;
+}
     
 int
 enet_socket_shutdown (ENetSocket socket, ENetSocketShutdown how)

--- a/win32.c
+++ b/win32.c
@@ -223,6 +223,24 @@ enet_socket_accept (ENetSocket socket, ENetAddress * address)
 }
 
 int
+enet_socket_get_address (ENetSocket socket, ENetAddress * address)
+{
+    // We're allocating only enough memory for an IPv4 address as IPv6 is
+    // currently unsupported. If socket were bound to an IPv6 address
+    // getsockname() would fail and enet_socket_get_address() would return -1.
+    struct sockaddr_in socket_address;
+    int socket_address_length = sizeof(struct sockaddr_in);
+
+    if (getsockname (socket, (struct sockaddr *) & socket_address, & socket_address_length) != 0)
+      return -1;
+
+    address->host = socket_address.sin_addr.s_addr;
+    address->port = socket_address.sin_port;
+
+    return 0;
+}
+
+int
 enet_socket_shutdown (ENetSocket socket, ENetSocketShutdown how)
 {
     return shutdown (socket, (int) how) == SOCKET_ERROR ? -1 : 0;


### PR DESCRIPTION
Typical use case: you're creating a host, you don't care about the port number so you're just using `ENET_PORT_ANY`, but after the host is created you'd like to show the user on what port the server actually listens.

If you'd check newly created `ENetHost`'s `address.port`, you'd find `ENET_PORT_ANY`. Now you'll find the correct, actual port the host is bound to.

This also exposes underlaying function (`enet_socket_get_address()`) as a part of API.

I have not tested this on Win32 (had no means to do so). On both Linux and OS X it works well, and the change itself is quite trivial, though it definitely should be tested on Win32 too.

Oh, and I guess this change is not backwards compatible.
