### PR TITLE
Use _WIN32 instead of WIN32

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -12,7 +12,7 @@ extern "C"
 
 #include <stdlib.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "enet/win32.h"
 #else
 #include "enet/unix.h"


### PR DESCRIPTION
This fixes mingw builds when using c++0x. It does not define WIN32
there. The issue is that projects which include enets headers cannot
compile with c++0x enabled and mingw because of this header generating
an error.
