### PR TITLE
Fix ENet signal handling on Unix -- encountered on Mono

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1795,6 +1795,7 @@ int
 enet_host_service (ENetHost * host, ENetEvent * event, enet_uint32 timeout)
 {
     enet_uint32 waitCondition;
+    int waitResult;
 
     if (event != NULL)
     {
@@ -1895,14 +1896,20 @@ enet_host_service (ENetHost * host, ENetEvent * event, enet_uint32 timeout)
           }
        }
 
-       host -> serviceTime = enet_time_get ();
+       do
+       {
+         host -> serviceTime = enet_time_get ();
 
-       if (ENET_TIME_GREATER_EQUAL (host -> serviceTime, timeout))
-         return 0;
+         if (ENET_TIME_GREATER_EQUAL (host -> serviceTime, timeout))
+           return 0;
 
-       waitCondition = ENET_SOCKET_WAIT_RECEIVE;
+         waitCondition = ENET_SOCKET_WAIT_RECEIVE;
 
-       if (enet_socket_wait (host -> socket, & waitCondition, ENET_TIME_DIFFERENCE (timeout, host -> serviceTime)) != 0)
+         waitResult = enet_socket_wait (host -> socket, & waitCondition, ENET_TIME_DIFFERENCE (timeout, host -> serviceTime));
+       }
+       while (waitResult == -2);
+       
+       if (waitResult != 0)
          return -1;
        
        host -> serviceTime = enet_time_get ();


### PR DESCRIPTION
Not handling these is a big problem for ENet with Mono.
Mono uses signals for its garbage collector, so EINTR happens all the time.
Right now, enet_host_service fails around the time Mono invokes its GC.

The only API change is the addition of -2 error code on enet_socket_wait.
This means 'recompute the timeout and retry'. It's unavoidable for correctness's sake.
Luckily ENet uses a < 0 convention for errors.

With this patch, I no longer receive spurious -1 failures on enet_host_service.

Have a good day :)

James
