### PR TITLE
Proof of concept for large data transfer utility to send large amount of data between two hosts.

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -329,7 +329,23 @@ typedef enet_uint32 (ENET_CALLBACK * ENetChecksumCallback) (const ENetBuffer * b
 
 /** Callback for intercepting received raw UDP packets. Should return 1 to intercept, 0 to ignore, or -1 to propagate an error. */
 typedef int (ENET_CALLBACK * ENetInterceptCallback) (struct _ENetHost * host, struct _ENetEvent * event);
- 
+
+/** callback used to provide data to be sent by a data job */
+typedef enet_uint32 (ENET_CALLBACK * ENetDataJobCallback) (void* _opaque, void* _buffer);
+typedef struct _ENetDataJob
+{
+	/** data jobs are stored in a chained list */
+	ENetListNode dataJobNode;
+	enet_uint32 id;
+	/** each job uses a fixed number of packets in flight */
+	ENetPacket** packets;
+	enet_uint32 nbPackets;
+	ENetPeer* sendee;
+	enet_uint8 channel;
+	ENetDataJobCallback callback;
+	void* opaque;
+} ENetDataJob;
+
 /** An ENet host for communicating with peers.
   *
   * No fields should be modified unless otherwise stated.
@@ -379,6 +395,8 @@ typedef struct _ENetHost
    enet_uint32          totalReceivedData;           /**< total data received, user should reset to 0 as needed to prevent overflow */
    enet_uint32          totalReceivedPackets;        /**< total UDP packets received, user should reset to 0 as needed to prevent overflow */
    ENetInterceptCallback intercept;                  /**< callback the user can set to intercept received raw UDP packets */
+   ENetList             dataJobs;
+   enet_uint32          nextDataJobId;
 } ENetHost;
 
 /**
@@ -525,18 +543,21 @@ ENET_API void         enet_packet_destroy (ENetPacket *);
 ENET_API int          enet_packet_resize  (ENetPacket *, size_t);
 ENET_API enet_uint32  enet_crc32 (const ENetBuffer *, size_t);
                 
-ENET_API ENetHost * enet_host_create (const ENetAddress *, size_t, size_t, enet_uint32, enet_uint32);
-ENET_API void       enet_host_destroy (ENetHost *);
-ENET_API ENetPeer * enet_host_connect (ENetHost *, const ENetAddress *, size_t, enet_uint32);
-ENET_API int        enet_host_check_events (ENetHost *, ENetEvent *);
-ENET_API int        enet_host_service (ENetHost *, ENetEvent *, enet_uint32);
-ENET_API void       enet_host_flush (ENetHost *);
-ENET_API void       enet_host_broadcast (ENetHost *, enet_uint8, ENetPacket *);
-ENET_API void       enet_host_compress (ENetHost *, const ENetCompressor *);
-ENET_API int        enet_host_compress_with_range_coder (ENetHost * host);
-ENET_API void       enet_host_channel_limit (ENetHost *, size_t);
-ENET_API void       enet_host_bandwidth_limit (ENetHost *, enet_uint32, enet_uint32);
-extern   void       enet_host_bandwidth_throttle (ENetHost *);
+ENET_API ENetHost *   enet_host_create (const ENetAddress *, size_t, size_t, enet_uint32, enet_uint32);
+ENET_API void         enet_host_destroy (ENetHost *);
+ENET_API ENetPeer *   enet_host_connect (ENetHost *, const ENetAddress *, size_t, enet_uint32);
+ENET_API int          enet_host_check_events (ENetHost *, ENetEvent *);
+ENET_API int          enet_host_service (ENetHost *, ENetEvent *, enet_uint32);
+ENET_API void         enet_host_flush (ENetHost *);
+ENET_API void         enet_host_broadcast (ENetHost *, enet_uint8, ENetPacket *);
+ENET_API void         enet_host_compress (ENetHost *, const ENetCompressor *);
+ENET_API int          enet_host_compress_with_range_coder (ENetHost * host);
+ENET_API void         enet_host_channel_limit (ENetHost *, size_t);
+ENET_API void         enet_host_bandwidth_limit (ENetHost *, enet_uint32, enet_uint32);
+extern   void         enet_host_bandwidth_throttle (ENetHost *);
+ENET_API enet_uint32  enet_host_register_datajob( ENetHost*, ENetPeer*, enet_uint8, ENetDataJobCallback, void*, enet_uint32, size_t);
+ENET_API enet_uint32  enet_host_process_datajobs( ENetHost * host);
+
 
 ENET_API int                 enet_peer_send (ENetPeer *, enet_uint8, ENetPacket *);
 ENET_API ENetPacket *        enet_peer_receive (ENetPeer *, enet_uint8 * channelID);


### PR DESCRIPTION
Usage:

Two connected hosts first agree on a channel to send the data through. They can do this any way they choose.

Once an agreement is reached, the receiving end is responsible for handling any data received in that channel.
On the sending side, a data job is created with enet_host_register_datajob(). The function receives, among other things, a callback that provides data.

The callback returns the amount of data written, and should return 0 when done. The callback receives a buffer pointer to write the data to. When the pointer is null, either the jobs has been cancelled or the job has completed. IT is then time to perform any necessary cleanup.

Cleanup on the receiving side is application dependant. For example, during channel negocation, the sender might provide the amount of data it wants to transfer. Then on the receiving end, a file where received data is stored should be closed when the receiver detects it has received the specified amount.

The sending application must also call enet_host_process_datajobs() when it knows jobs are registered (usually do this at the same time as enet_host_service).
