### PR TITLE
Added type enet_uint64 and changed the methods that uses the new type.

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -476,11 +476,11 @@ ENET_API ENetVersion enet_linked_version (void);
   Returns the wall-time in milliseconds.  Its initial value is unspecified
   unless otherwise set.
   */
-ENET_API enet_uint32 enet_time_get (void);
+ENET_API enet_uint64 enet_time_get (void);
 /**
   Sets the current wall-time in milliseconds.
   */
-ENET_API void enet_time_set (enet_uint32);
+ENET_API void enet_time_set (enet_uint64);
 
 /** @defgroup socket ENet socket functions
     @{
@@ -493,7 +493,7 @@ ENET_API ENetSocket enet_socket_accept (ENetSocket, ENetAddress *);
 ENET_API int        enet_socket_connect (ENetSocket, const ENetAddress *);
 ENET_API int        enet_socket_send (ENetSocket, const ENetAddress *, const ENetBuffer *, size_t);
 ENET_API int        enet_socket_receive (ENetSocket, ENetAddress *, ENetBuffer *, size_t);
-ENET_API int        enet_socket_wait (ENetSocket, enet_uint32 *, enet_uint32);
+ENET_API int        enet_socket_wait (ENetSocket, enet_uint32 *, enet_uint64);
 ENET_API int        enet_socket_set_option (ENetSocket, ENetSocketOption, int);
 ENET_API int        enet_socket_get_option (ENetSocket, ENetSocketOption, int *);
 ENET_API int        enet_socket_shutdown (ENetSocket, ENetSocketShutdown);
@@ -554,7 +554,7 @@ ENET_API int        enet_host_compress_with_range_coder (ENetHost * host);
 ENET_API void       enet_host_channel_limit (ENetHost *, size_t);
 ENET_API void       enet_host_bandwidth_limit (ENetHost *, enet_uint32, enet_uint32);
 extern   void       enet_host_bandwidth_throttle (ENetHost *);
-extern  enet_uint32 enet_host_random_seed (void);
+extern  enet_uint64 enet_host_random_seed (void);
 
 ENET_API int                 enet_peer_send (ENetPeer *, enet_uint8, ENetPacket *);
 ENET_API ENetPacket *        enet_peer_receive (ENetPeer *, enet_uint8 * channelID);

--- a/include/enet/types.h
+++ b/include/enet/types.h
@@ -5,9 +5,11 @@
 #ifndef __ENET_TYPES_H__
 #define __ENET_TYPES_H__
 
+
 typedef unsigned char enet_uint8;       /**< unsigned 8-bit type  */
 typedef unsigned short enet_uint16;     /**< unsigned 16-bit type */
 typedef unsigned int enet_uint32;      /**< unsigned 32-bit type */
+typedef u_int64_t enet_uint64;      /**< unsigned 64-bit type */
 
 #endif /* __ENET_TYPES_H__ */
 

--- a/unix.c
+++ b/unix.c
@@ -56,7 +56,7 @@ typedef int socklen_t;
 #define MSG_NOSIGNAL 0
 #endif
 
-static enet_uint32 timeBase = 0;
+static enet_uint64 timeBase = 0;
 
 int
 enet_initialize (void)
@@ -69,13 +69,13 @@ enet_deinitialize (void)
 {
 }
 
-enet_uint32
+enet_uint64
 enet_host_random_seed (void)
 {
-    return (enet_uint32) time (NULL);
+    return (enet_uint64) time (NULL);
 }
 
-enet_uint32
+enet_uint64
 enet_time_get (void)
 {
     struct timeval timeVal;
@@ -86,7 +86,7 @@ enet_time_get (void)
 }
 
 void
-enet_time_set (enet_uint32 newTimeBase)
+enet_time_set (enet_uint64 newTimeBase)
 {
     struct timeval timeVal;
 
@@ -466,7 +466,7 @@ enet_socketset_select (ENetSocket maxSocket, ENetSocketSet * readSet, ENetSocket
 }
 
 int
-enet_socket_wait (ENetSocket socket, enet_uint32 * condition, enet_uint32 timeout)
+enet_socket_wait (ENetSocket socket, enet_uint32 * condition, enet_uint64 timeout)
 {
 #ifdef HAS_POLL
     struct pollfd pollSocket;

--- a/win32.c
+++ b/win32.c
@@ -9,7 +9,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 
-static enet_uint32 timeBase = 0;
+static enet_uint64 timeBase = 0;
 
 int
 enet_initialize (void)
@@ -41,22 +41,22 @@ enet_deinitialize (void)
     WSACleanup ();
 }
 
-enet_uint32
+enet_uint64
 enet_host_random_seed (void)
 {
-    return (enet_uint32) timeGetTime ();
+    return (enet_uint64) timeGetTime ();
 }
 
-enet_uint32
+enet_uint64
 enet_time_get (void)
 {
-    return (enet_uint32) timeGetTime () - timeBase;
+    return (enet_uint64) timeGetTime () - timeBase;
 }
 
 void
-enet_time_set (enet_uint32 newTimeBase)
+enet_time_set (enet_uint64 newTimeBase)
 {
-    timeBase = (enet_uint32) timeGetTime () - newTimeBase;
+    timeBase = (enet_uint64) timeGetTime () - newTimeBase;
 }
 
 int
@@ -381,7 +381,7 @@ enet_socketset_select (ENetSocket maxSocket, ENetSocketSet * readSet, ENetSocket
 }
 
 int
-enet_socket_wait (ENetSocket socket, enet_uint32 * condition, enet_uint32 timeout)
+enet_socket_wait (ENetSocket socket, enet_uint32 * condition, enet_uint64 timeout)
 {
     fd_set readSet, writeSet;
     struct timeval timeVal;


### PR DESCRIPTION
For dates as Mon, 09 Mar 2015 19:25:42 GMT, whose value is 1425929142 seconds, the enet_uint32 type is overflow by passing this to milliseconds.