### PR TITLE
mingw dll build fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,12 @@ enetinclude_HEADERS = \
 lib_LTLIBRARIES = libenet.la
 libenet_la_SOURCES = callbacks.c compress.c host.c list.c packet.c peer.c protocol.c unix.c win32.c
 # see info '(libtool) Updating version info' before making a release
-libenet_la_LDFLAGS = $(AM_LDFLAGS) -version-info 7:1:0
+VERSIONINFO = -version-info 7:1:0
+if MINGW
+libenet_la_LDFLAGS = -no-undefined -lwinmm -lws2_32 $(AM_LDFLAGS) $(VERSIONINFO)
+else
+libenet_la_LDFLAGS = $(AM_LDFLAGS) $(VERSIONINFO)
+endif
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 ACLOCAL_AMFLAGS = -Im4

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,15 @@ AC_CHECK_TYPE(socklen_t, [AC_DEFINE(HAS_SOCKLEN_T)], ,
               #include <sys/socket.h>
 )
 
+case $host_os in
+    mingw* )
+        AM_CONDITIONAL([MINGW], [true])
+        ;;
+    * )
+        AM_CONDITIONAL([MINGW], [false])
+        ;;
+esac
+
 AC_CONFIG_FILES([Makefile
 	libenet.pc])
 AC_OUTPUT


### PR DESCRIPTION
This PR fixes

```
/bin/sh ./libtool  --tag=CC   --mode=link i686-w64-mingw32-gcc  [...]
libtool: warning: undefined symbols not allowed in i686-w64-mingw32 shared libraries; building static only
```
