### PR TITLE
Allow connecting to broadcast address for Windows

### DIFF
--- a/win32.c
+++ b/win32.c
@@ -8,6 +8,7 @@
 #include "enet/enet.h"
 #include <windows.h>
 #include <mmsystem.h>
+#include <Ws2tcpip.h>
 
 static enet_uint32 timeBase = 0;
 
@@ -68,10 +69,10 @@ enet_address_set_host (ENetAddress * address, const char * name)
     if (hostEntry == NULL ||
         hostEntry -> h_addrtype != AF_INET)
     {
-        unsigned long host = inet_addr (name);
-        if (host == INADDR_NONE)
+        struct sockaddr_in sa;
+        if (inet_pton(AF_INET, name, &sa.sin_addr) <= 0)
             return -1;
-        address -> host = host;
+        address -> host = (enet_uint32)sa.sin_addr.S_un.S_addr;
         return 0;
     }
 


### PR DESCRIPTION
Use inet_pton instead of inet_addr. INADDR_NONE has the same value as the broadcast address (255.255.255.255), making this address unusable.