### PR TITLE
Don't treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ check_type_size("socklen_t" HAS_SOCKLEN_T BUILTIN_TYPES_ONLY)
 unset(CMAKE_EXTRA_INCLUDE_FILES)
 if(MSVC)
 	add_definitions(-W3)
+else()
+	add_definitions(-Wno-error)
 endif()
  
 if(HAS_FCNTL)


### PR DESCRIPTION
When enet is included as a child CMake project in a parent that has warnings treated as errors, enet fails to build. This ensures that the compiler doesn't treat warnings as errors for enet.

Related to #70