### PR TITLE
Fix mingw compilation when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,3 +68,7 @@ add_library(enet STATIC
         unix.c
         win32.c
     )
+
+if (MINGW)
+    target_link_libraries(enet winmm ws2_32)
+endif()


### PR DESCRIPTION
In order to compile enet on mingw, you need to link against winmm and
ws2_32. This explicitly makes those libraries required on mingw