### PR TITLE
- Raised ENET_PROTOCOL_MAXIMUM_PEER_ID from 0xFFF to 0xFFFF

### DIFF
--- a/include/enet/protocol.h
+++ b/include/enet/protocol.h
@@ -16,7 +16,7 @@ enum
    ENET_PROTOCOL_MAXIMUM_WINDOW_SIZE     = 65536,
    ENET_PROTOCOL_MINIMUM_CHANNEL_COUNT   = 1,
    ENET_PROTOCOL_MAXIMUM_CHANNEL_COUNT   = 255,
-   ENET_PROTOCOL_MAXIMUM_PEER_ID         = 0xFFF,
+   ENET_PROTOCOL_MAXIMUM_PEER_ID         = 0xFFFF,
    ENET_PROTOCOL_MAXIMUM_FRAGMENT_COUNT  = 1024 * 1024
 };
 
@@ -65,6 +65,7 @@ typedef enum _ENetProtocolFlag
 typedef struct _ENetProtocolHeader
 {
    enet_uint16 peerID;
+   enet_uint16 flags;
    enet_uint16 sentTime;
 } ENET_PACKED ENetProtocolHeader;
 

--- a/protocol.c
+++ b/protocol.c
@@ -991,10 +991,10 @@ enet_protocol_handle_incoming_commands (ENetHost * host, ENetEvent * event)
     header = (ENetProtocolHeader *) host -> receivedData;
 
     peerID = ENET_NET_TO_HOST_16 (header -> peerID);
-    sessionID = (peerID & ENET_PROTOCOL_HEADER_SESSION_MASK) >> ENET_PROTOCOL_HEADER_SESSION_SHIFT;
-    flags = peerID & ENET_PROTOCOL_HEADER_FLAG_MASK;
-    peerID &= ~ (ENET_PROTOCOL_HEADER_FLAG_MASK | ENET_PROTOCOL_HEADER_SESSION_MASK);
-
+    flags = ENET_NET_TO_HOST_16 (header -> flags);
+    sessionID = (flags & ENET_PROTOCOL_HEADER_SESSION_MASK) >> ENET_PROTOCOL_HEADER_SESSION_SHIFT;
+    flags = flags & ENET_PROTOCOL_HEADER_FLAG_MASK;
+    
     headerSize = (flags & ENET_PROTOCOL_HEADER_FLAG_SENT_TIME ? sizeof (ENetProtocolHeader) : (size_t) & ((ENetProtocolHeader *) 0) -> sentTime);
     if (host -> checksum != NULL)
       headerSize += sizeof (enet_uint32);
@@ -1704,7 +1704,8 @@ enet_protocol_send_outgoing_commands (ENetHost * host, ENetEvent * event, int ch
 
         if (currentPeer -> outgoingPeerID < ENET_PROTOCOL_MAXIMUM_PEER_ID)
           host -> headerFlags |= currentPeer -> outgoingSessionID << ENET_PROTOCOL_HEADER_SESSION_SHIFT;
-        header -> peerID = ENET_HOST_TO_NET_16 (currentPeer -> outgoingPeerID | host -> headerFlags);
+        header -> peerID = ENET_HOST_TO_NET_16 (currentPeer -> outgoingPeerID);
+        header -> flags = ENET_HOST_TO_NET_16 (host -> headerFlags);
         if (host -> checksum != NULL)
         {
             enet_uint32 * checksum = (enet_uint32 *) & headerData [host -> buffers -> dataLength];


### PR DESCRIPTION
It requires only few code changes for raising ENET_PROTOCOL_MAXIMUM_PEER_ID from 0xFFF to 0xFFFF (which should be then enough in my opinion), but it breaks the protocol compatibly to vanilla upstream ENet, due to small changes in the _ENetProtocolHeader structure. It is just more or less a single-feature backport from my Pascal port of enet at https://github.com/BeRo1985/pasenet/commit/e06b3a95b6fbac5ce5dec2abb33edf5a611593ed . 