### PR TITLE
Add "application data" member to ENetHost struct

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -393,6 +393,7 @@ typedef struct _ENetHost
    size_t               duplicatePeers;              /**< optional number of allowed peers from duplicate IPs, defaults to ENET_PROTOCOL_MAXIMUM_PEER_ID */
    size_t               maximumPacketSize;           /**< the maximum allowable packet size that may be sent or received on a peer */
    size_t               maximumWaitingData;          /**< the maximum aggregate amount of buffer space a peer may use waiting for packets to be delivered */
+   void *               data;                        /**< Application private data, may be freely modified */
 } ENetHost;
 
 /**


### PR DESCRIPTION
ENetPeer struct contains void* data; member that is very useful for binding to application objects. ENetHost structure can also benefit from having this member.