### PR TITLE
Use <poll.h> instead of <sys/poll.h> in unix.c

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -51,7 +51,7 @@
 #endif
 
 #ifdef HAS_POLL
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 
 #ifndef HAS_SOCKLEN_T


### PR DESCRIPTION
<poll.h> is the correct POSIX header according to the POSIX standard. Some targets (like homebrew for the Nintendo Switch) do not provide a <sys/poll.h> so it makes compiling for them rather hard.