### PR TITLE
fix use-after-free bug in enet_peer_disconnect_later()

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1407,7 +1407,10 @@ enet_protocol_send_unreliable_outgoing_commands (ENetHost * host, ENetPeer * pee
         enet_list_empty (& peer -> outgoingReliableCommands) &&
         enet_list_empty (& peer -> outgoingUnreliableCommands) && 
         enet_list_empty (& peer -> sentReliableCommands))
+    {
       enet_peer_disconnect (peer, peer -> eventData);
+      host -> commandCount = 0;
+    }
 }
 
 static int


### PR DESCRIPTION
What happens is
* We call enet_peer_disconnect_later() which sets ENET_PEER_STATE_DISCONNECT_LATER
* Then what happens is (call-stack):
  1 enet_peer_reset_queues()
  2 enet_peer_disconnect()
  3 enet_protocol_send_unreliable_outgoing_commands()
  4 enet_protocol_send_outgoing_commands ()
  5 enet_host_service()

bug happens due to invalid condition in 3 where we already set
buffers/commands to send, but 1 clears data that this buffers are
pointing too (which later causing use-after-free on attempt to compress/encrypt it).
So we have to cleanup 'host -> commandCount' thus dropping unreliable
commands/dadta when switching from 'disconnect later' to 'disconnecting' state within
enet_protocol_send_unreliable_outgoing_commands()