### PR TITLE
Return 0 instead of -1 on enet_protocol_receive_incoming_commands

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1288,7 +1288,7 @@ enet_protocol_receive_incoming_commands (ENetHost * host, ENetEvent * event)
        }
     }
 
-    return -1;
+    return 0;
 }
 
 static void

--- a/unix.c
+++ b/unix.c
@@ -475,7 +475,7 @@ enet_socket_receive (ENetSocket socket,
 {
     struct msghdr msgHdr;
     struct sockaddr_in sin;
-    int recvLength = 0;
+    int recvLength;
 
     memset (& msgHdr, 0, sizeof (struct msghdr));
 

--- a/unix.c
+++ b/unix.c
@@ -475,7 +475,7 @@ enet_socket_receive (ENetSocket socket,
 {
     struct msghdr msgHdr;
     struct sockaddr_in sin;
-    int recvLength;
+    int recvLength = 0;
 
     memset (& msgHdr, 0, sizeof (struct msghdr));
 

--- a/win32.c
+++ b/win32.c
@@ -316,7 +316,7 @@ enet_socket_send (ENetSocket socket,
                   size_t bufferCount)
 {
     struct sockaddr_in sin;
-    DWORD sentLength;
+    DWORD sentLength = 0;
 
     if (address != NULL)
     {

--- a/win32.c
+++ b/win32.c
@@ -354,7 +354,7 @@ enet_socket_receive (ENetSocket socket,
 {
     INT sinLength = sizeof (struct sockaddr_in);
     DWORD flags = 0,
-          recvLength;
+          recvLength = 0;
     struct sockaddr_in sin;
 
     if (WSARecvFrom (socket,


### PR DESCRIPTION
Return 0 instead of -1 on enet_protocol_receive_incoming_commands when nothing received.
This allows the Service loop to continue running and not return an error when there is nothing to do with the socket receive.

From debugging I found sometimes the enet_protocol_receive_incoming_commands returns -1 because simply nothing happened in the 256 for loop.

Other functions like enet_protocol_send_outgoing_commands return 0 when nothing happened.
So I suppose we should mirror this behaviour. 