### PR TITLE
Update enet_packet_destroy documentation to reflect usage

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -50,7 +50,8 @@ enet_packet_create (const void * data, size_t dataLength, enet_uint32 flags)
     return packet;
 }
 
-/** Destroys the packet and deallocates its data.
+/** Destroys the packet and deallocates its data. Note that you should not call this if you pass the packet to
+    enet_peer_send, as that function will handle the destruction of the packet.
     @param packet packet to be destroyed
 */
 void


### PR DESCRIPTION
I was working on a project and kept getting a segfault until i read deeper into the docs to know that `enet_packet_send` takes ownership of the packet. It might be beneficial to document that nearer the destroy function, but honestly I'm not sure the best way to clarify.