### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ unset(CMAKE_EXTRA_INCLUDE_FILES)
 
 
 if (BUILD_SHARED_LIBS)
-    add_definitions(-DENET_SHARED_LIB=1)
+    add_definitions(-DENET_DLL=1)
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.4.3)
 
 project(enet)
 
@@ -96,5 +96,9 @@ add_library(enet
 )
 
 if (WIN32)
+    if (BUILD_SHARED_LIBS)
+        set_property(TARGET enet PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
+
     target_link_libraries(enet winmm ws2_32)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ unset(CMAKE_EXTRA_INCLUDE_FILES)
 
 
 if (BUILD_SHARED_LIBS)
-    add_definitions(-DENET_STATIC_LIB=1)
+    add_definitions(-DENET_SHARED_LIB=1)
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,6 @@ add_library(enet
     ${SOURCE_FILES}
 )
 
-if (MINGW OR MSVC)
+if (WIN32)
     target_link_libraries(enet winmm ws2_32)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,15 @@ check_struct_has_member("struct msghdr" "msg_flags" "sys/types.h;sys/socket.h" H
 set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h" "sys/socket.h")
 check_type_size("socklen_t" HAS_SOCKLEN_T BUILTIN_TYPES_ONLY)
 unset(CMAKE_EXTRA_INCLUDE_FILES)
+
+set(ENET_BUILD_LIBTYPE "STATIC" CACHE STRING "ENet library build type. (SHARED/STATIC)")
+
+if (ENET_BUILD_LIBTYPE STREQUAL "STATIC")
+    add_definitions(-DENET_STATIC_LIB=1)
+endif()
+
 if(MSVC)
-	add_definitions(-W3)
+add_definitions(-W3)
 else()
 	add_definitions(-Wno-error)
 endif()
@@ -84,7 +91,7 @@ set(SOURCE_FILES
 source_group(include FILES ${INCLUDE_FILES})
 source_group(source FILES ${SOURCE_FILES})
 
-add_library(enet STATIC
+add_library(enet ${ENET_BUILD_LIBTYPE}
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,6 @@ add_library(enet STATIC
     ${SOURCE_FILES}
 )
 
-if (MINGW)
+if (MINGW OR MSVC)
     target_link_libraries(enet winmm ws2_32)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 if(MSVC)
-add_definitions(-W3)
+	add_definitions(-W3)
 else()
 	add_definitions(-Wno-error)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,8 @@ set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h" "sys/socket.h")
 check_type_size("socklen_t" HAS_SOCKLEN_T BUILTIN_TYPES_ONLY)
 unset(CMAKE_EXTRA_INCLUDE_FILES)
 
-set(ENET_BUILD_LIBTYPE "STATIC" CACHE STRING "ENet library build type. (SHARED/STATIC)")
 
-if (ENET_BUILD_LIBTYPE STREQUAL "STATIC")
+if (BUILD_SHARED_LIBS)
     add_definitions(-DENET_STATIC_LIB=1)
 endif()
 
@@ -91,7 +90,7 @@ set(SOURCE_FILES
 source_group(include FILES ${INCLUDE_FILES})
 source_group(source FILES ${SOURCE_FILES})
 
-add_library(enet ${ENET_BUILD_LIBTYPE}
+add_library(enet
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )


### PR DESCRIPTION
This is PR https://github.com/lsalzman/enet/pull/137 (which I messed up, my bad) plus new changes.

Changes are:
- Upgrading from CMake 2.6 to 3.4.3
- Linking against `ws2_32` and `winmm` if compiler is MSVC
- Conditionally defining `ENET_DLL` macro
- Exporting all symbols for Win32 so that a `.def` file or `__declspec(dllexport)` is not required