### PR TITLE
fix build as dll on msvc 2019 (windows)

### DIFF
--- a/peer.c
+++ b/peer.c
@@ -99,12 +99,14 @@ enet_peer_throttle (ENetPeer * peer, enet_uint32 rtt)
 int
 enet_peer_send (ENetPeer * peer, enet_uint8 channelID, ENetPacket * packet)
 {
+   if (peer->state != ENET_PEER_STATE_CONNECTED)
+       return -1;
+ 
    ENetChannel * channel = & peer -> channels [channelID];
    ENetProtocol command;
    size_t fragmentLength;
 
-   if (peer -> state != ENET_PEER_STATE_CONNECTED ||
-       channelID >= peer -> channelCount ||
+   if (channelID >= peer -> channelCount ||
        packet -> dataLength > peer -> host -> maximumPacketSize)
      return -1;
 

--- a/protocol.c
+++ b/protocol.c
@@ -1390,7 +1390,7 @@ enet_protocol_check_outgoing_commands (ENetHost * host, ENetPeer * peer)
     ENetBuffer * buffer = & host -> buffers [host -> bufferCount];
     ENetOutgoingCommand * outgoingCommand;
     ENetListIterator currentCommand;
-    ENetChannel *channel;
+    ENetChannel *channel = NULL;
     enet_uint16 reliableWindow;
     size_t commandSize;
     int windowExceeded = 0, windowWrap = 0, canPing = 1;

--- a/win32.c
+++ b/win32.c
@@ -9,6 +9,8 @@
 #include <windows.h>
 #include <mmsystem.h>
 
+#pragma warning (disable : 4996)
+
 static enet_uint32 timeBase = 0;
 
 int


### PR DESCRIPTION
I had a few compiler issues when trying to build it, disabling the warning C4996 in win32.c and setting ENetChannel *channel to NULL fixed this, as it complained for being "uninitialized but being used at the same time".