### PR TITLE
Fix CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.6...3.19)
 
 project(enet)
 
@@ -89,6 +89,8 @@ add_library(enet STATIC
     ${SOURCE_FILES}
 )
 
-if (MINGW)
+target_include_directories(enet PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+if (MINGW OR MSVC)
     target_link_libraries(enet winmm ws2_32)
 endif()


### PR DESCRIPTION
Hey,

I've noticed few issues with using CMake and ENet. Issues what I've experienced were
- include directory was not properly working, so i had to use relative paths 
- msvc requires you to link ws2_32 and winmm libraries in order to work properly too
- cmake deprecation warning of version 2.xx's.