### PR TITLE
Fix too late ENET_PEER_STATE_CONNECTED check upon enet_peer_send

### DIFF
--- a/peer.c
+++ b/peer.c
@@ -99,12 +99,14 @@ enet_peer_throttle (ENetPeer * peer, enet_uint32 rtt)
 int
 enet_peer_send (ENetPeer * peer, enet_uint8 channelID, ENetPacket * packet)
 {
+   if (peer->state != ENET_PEER_STATE_CONNECTED)
+       return -1;
+ 
    ENetChannel * channel = & peer -> channels [channelID];
    ENetProtocol command;
    size_t fragmentLength;
 
-   if (peer -> state != ENET_PEER_STATE_CONNECTED ||
-       channelID >= peer -> channelCount ||
+   if (channelID >= peer -> channelCount ||
        packet -> dataLength > peer -> host -> maximumPacketSize)
      return -1;
 

--- a/peer.c
+++ b/peer.c
@@ -99,17 +99,14 @@ enet_peer_throttle (ENetPeer * peer, enet_uint32 rtt)
 int
 enet_peer_send (ENetPeer * peer, enet_uint8 channelID, ENetPacket * packet)
 {
-   if (peer->state != ENET_PEER_STATE_CONNECTED)
-       return -1;
+   if (channelID >= peer -> channelCount ||
+       packet -> dataLength > peer -> host -> maximumPacketSize)
+     return -1;
  
    ENetChannel * channel = & peer -> channels [channelID];
    ENetProtocol command;
    size_t fragmentLength;
-
-   if (channelID >= peer -> channelCount ||
-       packet -> dataLength > peer -> host -> maximumPacketSize)
-     return -1;
-
+ 
    fragmentLength = peer -> mtu - sizeof (ENetProtocolHeader) - sizeof (ENetProtocolSendFragment);
    if (peer -> host -> checksum != NULL)
      fragmentLength -= sizeof(enet_uint32);

--- a/protocol.c
+++ b/protocol.c
@@ -1390,7 +1390,7 @@ enet_protocol_check_outgoing_commands (ENetHost * host, ENetPeer * peer)
     ENetBuffer * buffer = & host -> buffers [host -> bufferCount];
     ENetOutgoingCommand * outgoingCommand;
     ENetListIterator currentCommand;
-    ENetChannel *channel;
+    ENetChannel *channel = NULL;
     enet_uint16 reliableWindow;
     size_t commandSize;
     int windowExceeded = 0, windowWrap = 0, canPing = 1;

--- a/win32.c
+++ b/win32.c
@@ -9,6 +9,8 @@
 #include <windows.h>
 #include <mmsystem.h>
 
+#pragma warning (disable : 4996)
+
 static enet_uint32 timeBase = 0;
 
 int


### PR DESCRIPTION
A potential out of bounds could occur where one misuses enet_peer_send without manually checking if peer->state was ENET_PEER_STATE_CONNECTED before, as a reference of ENetChannel in peer -> channels was attempted to be accessed after before checking if target ENetPeer is even connected. Since peer -> channels is not fixed and is dynamically allocated on connect and deallocated + set to NULL on enet_peer_reset_queues, accessing & peer -> channels [channelID] can cause an out of bounds, making the peer->state != ENET_PEER_STATE_CONNECTED check useless anywhere below.