### PR TITLE
fix RTO limit being exceeded during exponential backoff

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1368,6 +1368,8 @@ enet_protocol_check_timeouts (ENetHost * host, ENetPeer * peer, ENetEvent * even
        ++ peer -> packetsLost;
 
        outgoingCommand -> roundTripTimeout *= 2;
+       if (outgoingCommand -> roundTripTimeout > outgoingCommand -> roundTripTimeoutLimit)
+         outgoingCommand -> roundTripTimeout = outgoingCommand -> roundTripTimeoutLimit;
 
        enet_list_insert (insertPosition, enet_list_remove (& outgoingCommand -> outgoingCommandList));
 


### PR DESCRIPTION
This addresses the issue described in #159 by capping the RTO at `outgoingCommand -> roundTripTimeoutLimit` which takes into account the `timeoutLimit` parameter passed to `enet_peer_timeout()`.

Fixes #159 