### PR TITLE
Add install to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,3 +92,8 @@ add_library(enet STATIC
 if (MINGW)
     target_link_libraries(enet winmm ws2_32)
 endif()
+
+install(FILES ${INCLUDE_FILES} DESTINATION ${INCLUDE_FILES_PREFIX})
+install(TARGETS enet RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+                     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+                     ARCHIVE DESTINATION ${LIB_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,12 +84,16 @@ set(SOURCE_FILES
 source_group(include FILES ${INCLUDE_FILES})
 source_group(source FILES ${SOURCE_FILES})
 
-add_library(enet STATIC
+add_library(enet
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )
 
-if (MINGW)
+if (WIN32)
+    if (BUILD_SHARED_LIBS)
+        set_property(TARGET enet PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
+
     target_link_libraries(enet winmm ws2_32)
 endif()
 


### PR DESCRIPTION
Currently CMakeLists.txt lacks any installation instruction, which is a bit annoying when you wish to install it in system folders (using make install), this PR fixes that.