### PR TITLE
Future proof cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.20)
 
 project(enet)
 


### PR DESCRIPTION
This lets cmake know that the project is compatible and has been tested with even higher versions of cmake.