### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         build_type: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+
+name: CMake
+
+jobs:
+  cmake-build:
+    name: CMake ${{ matrix.os }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        build_type: ["Debug", "Release"]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.build_type }}      


### PR DESCRIPTION
This adds some basic CI builds via GitHub Actions.

This produces a build matrix `[Linux, Windows, MacOS]` x `[Debug, Release]` and builds ENet with CMake with the default detected compiler in the respective GitHub Actions environment (currently: GCC 9, Visual Studio 2019 and Apple Clang 13).

Later on, this could be extended to cover more compilers, compiler versions and build systems (Makefile, Premake), but it is a start to get some CI going for ENet.

An exemplary run can be seen here: https://github.com/Croydon/enet/actions/runs/4323673027

If this is merged, GitHub will run this CI for every future push and pull request, no further configuration is required whatsoever.