### PR TITLE
[FIX] CRC32 data race when using multiple ENetHost's from distinct threads

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -339,7 +339,7 @@ typedef struct _ENetCompressor
 } ENetCompressor;
 
 /** Callback that computes the checksum of the data held in buffers[0:bufferCount-1] */
-typedef enet_uint32 (ENET_CALLBACK * ENetChecksumCallback) (const ENetBuffer * buffers, size_t bufferCount);
+typedef enet_uint32 (ENET_CALLBACK * ENetChecksumCallback) (struct _ENetHost* host, const ENetBuffer * buffers, size_t bufferCount);
 
 /** Callback for intercepting received raw UDP packets. Should return 1 to intercept, 0 to ignore, or -1 to propagate an error. */
 typedef int (ENET_CALLBACK * ENetInterceptCallback) (struct _ENetHost * host, struct _ENetEvent * event);
@@ -398,6 +398,8 @@ typedef struct _ENetHost
    size_t               duplicatePeers;              /**< optional number of allowed peers from duplicate IPs, defaults to ENET_PROTOCOL_MAXIMUM_PEER_ID */
    size_t               maximumPacketSize;           /**< the maximum allowable packet size that may be sent or received on a peer */
    size_t               maximumWaitingData;          /**< the maximum aggregate amount of buffer space a peer may use waiting for packets to be delivered */
+   int                  initializedCRC32;
+   enet_uint32          crcTable[256];
 } ENetHost;
 
 /**
@@ -560,7 +562,8 @@ ENET_API int enet_address_get_host (const ENetAddress * address, char * hostName
 ENET_API ENetPacket * enet_packet_create (const void *, size_t, enet_uint32);
 ENET_API void         enet_packet_destroy (ENetPacket *);
 ENET_API int          enet_packet_resize  (ENetPacket *, size_t);
-ENET_API enet_uint32  enet_crc32 (const ENetBuffer *, size_t);
+ENET_API enet_uint32  enet_host_crc32 (ENetHost *, const ENetBuffer *, size_t);
+ENET_API void         enet_host_initialize_crc32 (ENetHost *);
                 
 ENET_API ENetHost * enet_host_create (const ENetAddress *, size_t, size_t, enet_uint32, enet_uint32);
 ENET_API void       enet_host_destroy (ENetHost *);

--- a/packet.c
+++ b/packet.c
@@ -98,9 +98,6 @@ enet_packet_resize (ENetPacket * packet, size_t dataLength)
     return 0;
 }
 
-static int initializedCRC32 = 0;
-static enet_uint32 crcTable [256];
-
 static enet_uint32 
 reflect_crc (int val, int bits)
 {
@@ -115,8 +112,8 @@ reflect_crc (int val, int bits)
     return result;
 }
 
-static void 
-initialize_crc32 (void)
+void 
+enet_host_initialize_crc32 (ENetHost * host)
 {
     int byte;
 
@@ -133,18 +130,18 @@ initialize_crc32 (void)
                 crc <<= 1;
         }
 
-        crcTable [byte] = reflect_crc (crc, 32);
+        host -> crcTable [byte] = reflect_crc (crc, 32);
     }
 
-    initializedCRC32 = 1;
+    host -> initializedCRC32 = 1;
 }
     
 enet_uint32
-enet_crc32 (const ENetBuffer * buffers, size_t bufferCount)
+enet_host_crc32 (ENetHost * host, const ENetBuffer * buffers, size_t bufferCount)
 {
     enet_uint32 crc = 0xFFFFFFFF;
     
-    if (! initializedCRC32) initialize_crc32 ();
+    if (! host -> initializedCRC32) enet_host_initialize_crc32 (host);
 
     while (bufferCount -- > 0)
     {
@@ -153,7 +150,7 @@ enet_crc32 (const ENetBuffer * buffers, size_t bufferCount)
 
         while (data < dataEnd)
         {
-            crc = (crc >> 8) ^ crcTable [(crc & 0xFF) ^ *data++];        
+            crc = (crc >> 8) ^ host -> crcTable [(crc & 0xFF) ^ *data++];        
         }
 
         ++ buffers;

--- a/protocol.c
+++ b/protocol.c
@@ -1069,7 +1069,7 @@ enet_protocol_handle_incoming_commands (ENetHost * host, ENetEvent * event)
         buffer.data = host -> receivedData;
         buffer.dataLength = host -> receivedDataLength;
 
-        if (host -> checksum (& buffer, 1) != desiredChecksum)
+        if (host -> checksum (host, & buffer, 1) != desiredChecksum)
           return 0;
     }
        
@@ -1674,7 +1674,7 @@ enet_protocol_send_outgoing_commands (ENetHost * host, ENetEvent * event, int ch
             enet_uint32 * checksum = (enet_uint32 *) & headerData [host -> buffers -> dataLength];
             * checksum = currentPeer -> outgoingPeerID < ENET_PROTOCOL_MAXIMUM_PEER_ID ? currentPeer -> connectID : 0;
             host -> buffers -> dataLength += sizeof (enet_uint32);
-            * checksum = host -> checksum (host -> buffers, host -> bufferCount);
+            * checksum = host -> checksum (host, host -> buffers, host -> bufferCount);
         }
 
         if (shouldCompress > 0)


### PR DESCRIPTION
Hello!

I have noticed that when using ENet from multiple threads, the CRC32 checksum sometimes seems to have miscalculations, resulting in unwanted retransmissions within ENet itself when a packet was sent with ENET_PACKET_FLAG_RELIABLE, even worse is that such packets would've been discarded completely if the reliability flag wasn't set, as the checksum wouldn't match...

As many codebases make use of multithreading (since it is favorable to utilize the CPU to its full extent), the only viable way is to either supply multiple ENetHost's (e.g when wanting to deploy multiple servers for a service), or when wanting to have multiple clients separately with the full performance of all CPU cores.

![image](https://user-images.githubusercontent.com/62474734/159575087-a8edd841-a50f-44f7-9725-62b6c30412e2.png)
ENet (according to the image), promises to work fine in a **multithreaded environment**, however I believe this may not apply to the checksum calculation, as that seems to require static global variables such as "crcTable" and "initializedCRC32". This could break the promise of full thread-safety even when the end-user makes sure that the ENetHosts operate distinct and separately.

As a result, a modification (in my opinion an improvement) had to be done to the design of ENet:
*enet_uint32 crcTable[256]* and *int initializedCRC32* are now members of the ENetHost structure.
For authenticity, enet_crc32 and the **ENetChecksumCallback** now have to be called with an ENetHost pointer and enet_crc32 is now called *enet_host_crc32*. For the internal initialization, *enet_host_initialize_crc32* is now being used to initialize ENet's implementation of the CRC32 checksum.

The reason I believe this is also more authentic, is because the **ENetInterceptCallback** also requires an ENetHost * - already. Now by making crcTable and initializedCRC32 members of ENetHost, it has also been made necessary to pass an ENetHost * to the checksum callback - in order to fix the data race / minuscule multithreading issue as mentioned above.