### PR TITLE
Added missing LT_INIT to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_CONFIG_SRCDIR([include/enet/enet.h])
 AM_INIT_AUTOMAKE([foreign])
 
 AC_CONFIG_MACRO_DIR([m4])
+LT_INIT
 
 AC_PROG_CC
 AC_PROG_LIBTOOL


### PR DESCRIPTION
After adding LT_INIT to configure.ac `autoreconf -ivf && automake` is able to produce configure script