### PR TITLE
Fold very long line

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -1626,7 +1626,16 @@ enet_protocol_send_outgoing_commands (ENetHost * host, ENetEvent * event, int ch
            enet_uint32 packetLoss = currentPeer -> packetsLost * ENET_PEER_PACKET_LOSS_SCALE / currentPeer -> packetsSent;
 
 #ifdef ENET_DEBUG
-           printf ("peer %u: %f%%+-%f%% packet loss, %u+-%u ms round trip time, %f%% throttle, %u outgoing, %u/%u incoming\n", currentPeer -> incomingPeerID, currentPeer -> packetLoss / (float) ENET_PEER_PACKET_LOSS_SCALE, currentPeer -> packetLossVariance / (float) ENET_PEER_PACKET_LOSS_SCALE, currentPeer -> roundTripTime, currentPeer -> roundTripTimeVariance, currentPeer -> packetThrottle / (float) ENET_PEER_PACKET_THROTTLE_SCALE, enet_list_size (& currentPeer -> outgoingCommands), currentPeer -> channels != NULL ? enet_list_size (& currentPeer -> channels -> incomingReliableCommands) : 0, currentPeer -> channels != NULL ? enet_list_size (& currentPeer -> channels -> incomingUnreliableCommands) : 0);
+           printf ("peer %u: %f%%+-%f%% packet loss, %u+-%u ms round trip time, %f%% throttle, %u outgoing, %u/%u incoming\n",
+			   currentPeer -> incomingPeerID,
+			   currentPeer -> packetLoss / (float) ENET_PEER_PACKET_LOSS_SCALE,
+			   currentPeer -> packetLossVariance / (float) ENET_PEER_PACKET_LOSS_SCALE,
+			   currentPeer -> roundTripTime,
+			   currentPeer -> roundTripTimeVariance,
+			   currentPeer -> packetThrottle / (float) ENET_PEER_PACKET_THROTTLE_SCALE,
+			   enet_list_size (& currentPeer -> outgoingCommands),
+			   currentPeer -> channels != NULL ? enet_list_size (& currentPeer -> channels -> incomingReliableCommands) : 0,
+			   currentPeer -> channels != NULL ? enet_list_size (& currentPeer -> channels -> incomingUnreliableCommands) : 0);
 #endif
 
            currentPeer -> packetLossVariance = (currentPeer -> packetLossVariance * 3 + ENET_DIFFERENCE (packetLoss, currentPeer -> packetLoss)) / 4;


### PR DESCRIPTION
Hi,

There is a very long line in protocol.c, which could be problematic according to a package checker lintian [0].
This patch tries to fold such a long line so it will help address the lintian report and improve the code readability.
Note that there is no functional change in it.

If you don't mind, please consider applying this patch.

[0] https://lintian.debian.org/tags/very-long-line-length-in-source-file