### PR TITLE
Add ENET_SOCKOPT_TTL

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -62,7 +62,8 @@ typedef enum _ENetSocketOption
    ENET_SOCKOPT_RCVTIMEO  = 6,
    ENET_SOCKOPT_SNDTIMEO  = 7,
    ENET_SOCKOPT_ERROR     = 8,
-   ENET_SOCKOPT_NODELAY   = 9
+   ENET_SOCKOPT_NODELAY   = 9,
+   ENET_SOCKOPT_TTL       = 10
 } ENetSocketOption;
 
 typedef enum _ENetSocketShutdown

--- a/unix.c
+++ b/unix.c
@@ -348,6 +348,10 @@ enet_socket_set_option (ENetSocket socket, ENetSocketOption option, int value)
             result = setsockopt (socket, IPPROTO_TCP, TCP_NODELAY, (char *) & value, sizeof (int));
             break;
 
+        case ENET_SOCKOPT_TTL:
+            result = setsockopt (socket, IPPROTO_IP, IP_TTL, (char *) & value, sizeof (int));
+            break;
+
         default:
             break;
     }
@@ -364,6 +368,11 @@ enet_socket_get_option (ENetSocket socket, ENetSocketOption option, int * value)
         case ENET_SOCKOPT_ERROR:
             len = sizeof (int);
             result = getsockopt (socket, SOL_SOCKET, SO_ERROR, value, & len);
+            break;
+
+        case ENET_SOCKOPT_TTL:
+            len = sizeof (int);
+            result = getsockopt (socket, IPPROTO_IP, IP_TTL, (char *) value, & len);
             break;
 
         default:

--- a/win32.c
+++ b/win32.c
@@ -8,6 +8,7 @@
 #include "enet/enet.h"
 #include <windows.h>
 #include <mmsystem.h>
+#include <ws2ipdef.h>
 
 static enet_uint32 timeBase = 0;
 
@@ -231,6 +232,10 @@ enet_socket_set_option (ENetSocket socket, ENetSocketOption option, int value)
             result = setsockopt (socket, IPPROTO_TCP, TCP_NODELAY, (char *) & value, sizeof (int));
             break;
 
+        case ENET_SOCKOPT_TTL:
+            result = setsockopt (socket, IPPROTO_IP, IP_TTL, (char *) & value, sizeof (int));
+            break;
+
         default:
             break;
     }
@@ -246,6 +251,11 @@ enet_socket_get_option (ENetSocket socket, ENetSocketOption option, int * value)
         case ENET_SOCKOPT_ERROR:
             len = sizeof(int);
             result = getsockopt (socket, SOL_SOCKET, SO_ERROR, (char *) value, & len);
+            break;
+
+        case ENET_SOCKOPT_TTL:
+            len = sizeof(int);
+            result = getsockopt (socket, IPPROTO_IP, IP_TTL, (char *) value, & len);
             break;
 
         default:


### PR DESCRIPTION
The currently popular methods for NAT traversal involve having two clients send each other a UDP packet. This adds an entry to their NAT, linking their endpoint to the other client, which means the other client can reply, allowing communication. However, this doesn't work for everyone: some NATs, upon receiving an unsolicited packet, will add an entry linking that packet's source to the NAT itself, which completely blocks communication. The solution is to ensure the first packet does not reach the other side, by giving it an appropriate TTL value.

This PR adds `ENET_SOCKOPT_TTL`, allowing for setting/getting a socket's TTL value and making this technique possible. I wrote [a simple C program](https://gist.github.com/skyfloogle/719a56c24df260c7f562b039dcf449a3) using this PR that tests whether a given TTL value is high enough to get past the NAT.

This technique doesn't appear to be very widely known, but I can confirm its usefulness. Additional information and resources are noted at https://github.com/dolphin-emu/dolphin/pull/11382.