### PR TITLE
Fix MTU negotiation on server side

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -384,7 +384,8 @@ enet_protocol_handle_connect (ENetHost * host, ENetProtocolHeader * header, ENet
     if (mtu > ENET_PROTOCOL_MAXIMUM_MTU)
       mtu = ENET_PROTOCOL_MAXIMUM_MTU;
 
-    peer -> mtu = mtu;
+    if (mtu < peer -> mtu)
+      peer -> mtu = mtu;
 
     if (host -> outgoingBandwidth == 0 &&
         peer -> incomingBandwidth == 0)


### PR DESCRIPTION
On connect the MTU sent by the client gets stored and sent back unchanged if within minimum and maximum of the protocol. Then on verify connect a test is done if the returned MTU is smaller than the current MTU and if so gets adjusted. So as long as the MTU is within boundaries only the client specified MTU is relevant.

This patch adds a check for smaller MTU on server side.