### PR TITLE
Improve CMake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(SOURCE_FILES
 source_group(include FILES ${INCLUDE_FILES})
 source_group(source FILES ${SOURCE_FILES})
 
-add_library(enet STATIC
+add_library(enet
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12...3.20)
 
-project(enet)
+# I.e. The ABI version
+project(enet VERSION 7.0.5)
+set(ENET_VERSION "1.3.17")
 
 # The "configure" step.
 include(CheckFunctionExists)
@@ -89,6 +91,10 @@ add_library(enet
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )
+set_target_properties(enet PROPERTIES
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION ${PROJECT_VERSION}
+)
 
 if (MINGW)
     target_link_libraries(enet winmm ws2_32)
@@ -101,3 +107,13 @@ install(TARGETS enet
 
 install(DIRECTORY include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Add variables for substitution in libenet.pc.in
+set(PACKAGE_VERSION ${ENET_VERSION})
+set(PACKAGE_NAME "lib${PROJECT_NAME}")
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+configure_file(libenet.pc.in libenet.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libenet.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(enet)
 include(CheckFunctionExists)
 include(CheckStructHasMember)
 include(CheckTypeSize)
+include(GNUInstallDirs)
 check_function_exists("fcntl" HAS_FCNTL)
 check_function_exists("poll" HAS_POLL)
 check_function_exists("getaddrinfo" HAS_GETADDRINFO)
@@ -94,9 +95,9 @@ if (MINGW)
 endif()
 
 install(TARGETS enet
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib/static
-    LIBRARY DESTINATION lib)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(DIRECTORY include/
-        DESTINATION include)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
- Use [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) to determine install paths
- Include libenet.pc in installation
- Add missing project version
- Fix missing shared library symlinks
- Don't default to building static libenet (Use `-DBUILD_SHARED_LIBS=(ON|OFF)` to control whether to build shared-only
(ON) or static-only (OFF) libraries.)
