### PR TITLE
add ws2tcpip.h library for mingw64 compile support

### DIFF
--- a/win32.c
+++ b/win32.c
@@ -9,6 +9,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <ws2ipdef.h>
+#include <ws2tcpip.h>
 
 static enet_uint32 timeBase = 0;
 


### PR DESCRIPTION
Add missing library for mingw64 support, introduced by new feature from [Add ENET_SOCKOPT_TTL](https://github.com/lsalzman/enet/pull/217)
