### PR TITLE
CMake: Fix linking for Windows builds with non-MinGW compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ add_library(enet STATIC
     ${SOURCE_FILES}
 )
 
-if (MINGW)
+if (WIN32)
     target_link_libraries(enet winmm ws2_32)
 endif()
 


### PR DESCRIPTION
There are many open pull requests that have this change already included, but via #174 @lsalzman wishes for atomic pull requests.

So this pull request applies a minimal change to have CMake outputting functional Windows builds, while compiling with compilers other than MinGW.

Windows builds of enet always need to get linked to `winmm` and `ws2_32`.

`if(WIN32)` is `true` when the target platform is Windows, so this works for cross-compiling and native compiling with any compiler. 