### PR TITLE
CMake: Enable shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,12 @@ set(SOURCE_FILES
 source_group(include FILES ${INCLUDE_FILES})
 source_group(source FILES ${SOURCE_FILES})
 
-add_library(enet STATIC
+if(WIN32 AND BUILD_SHARED_LIBS AND (MSVC OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    add_definitions(-DENET_DLL=1)
+    add_definitions(-DENET_BUILDING_LIB)
+endif()
+
+add_library(enet
     ${INCLUDE_FILES}
     ${SOURCE_FILES}
 )


### PR DESCRIPTION
Currently, the CMake file hard-configured a static build of enet. These are the minimal changes required to enable shared builds of enet as well.

CMake has the default [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/v3.29/variable/BUILD_SHARED_LIBS.html) option to determinate if a shared or static build is desired.

For builds that
  * are shared
  * and target Windows
  * and are either compiled with MSVC or Clang
 
 the following two definitions are declared: 
  * `ENET_DLL` (see [documentation](https://github.com/lsalzman/enet/blob/276ff5ae05a245bcee195af9c9fd002851517d40/docs/install.dox#L57))
  * `ENET_BUILDING_LIB`

Why only for MSVC and Clang? Because enet then makes use of `__declspec` here:
https://github.com/lsalzman/enet/blob/276ff5ae05a245bcee195af9c9fd002851517d40/include/enet/win32.h#L40
And this is only available with MSVC and with Clang when compiling for Windows.

___

  * This fixes #2.
  * This pull request, together with the merged changes of #241 and #187, also makes #147 obsolete. Closing #147.
  * Visual Studio has official, first-class support for CMake projects. Therefore allowing easily shared enet builds with VS when these changes are applied (together with the previously merged #241). Fixing #106.