### PR TITLE
CMake: Improve install instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,12 @@ if (WIN32)
     target_link_libraries(enet winmm ws2_32)
 endif()
 
+include(GNUInstallDirs)
 install(TARGETS enet
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib/static
-    LIBRARY DESTINATION lib)
-
-install(DIRECTORY include/
-        DESTINATION include)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/enet
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)


### PR DESCRIPTION
This improves the CMake install instructions. The destination paths should not be hard-coded, but set as variables via [GnuInstallDirs](https://cmake.org/cmake/help/v3.29/module/GNUInstallDirs.html).

This is particularly important for package managers like Conan that require files to be installed in a custom directory.

PS: Merging this will make the [Conan enet package](https://github.com/conan-io/conan-center-index/tree/master/recipes/enet/all) patch free for the first time. Although other package managers like vcpkg will still carry additional CMake patches for now.
___

  * Closes #184
  * Closes #104
  * Closes #147 (I meant to specify this in #242 already, but messed up the keyword, `closing` vs `closes`)