### PR TITLE
CMake: set project `LANGUAGES` to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12...3.20)
 
-project(enet)
+project(enet LANGUAGES C)
 
 # The "configure" step.
 include(CheckFunctionExists)


### PR DESCRIPTION
This avoids an unnecessary check / requirement for a C++ compiler even though this library only needs a working C compiler.
