### PR TITLE
Fix compiler warnings on Windows due to redefines

### DIFF
--- a/include/enet/win32.h
+++ b/include/enet/win32.h
@@ -11,8 +11,12 @@
 #pragma warning (disable: 4244) // 64bit to 32bit int
 #pragma warning (disable: 4018) // signed/unsigned mismatch
 #pragma warning (disable: 4146) // unary minus operator applied to unsigned type
+#ifndef _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_DEPRECATE
+#endif
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
The defines were already set globally in our environment when building with VS2019, causing warnings due to redefines (and we treat all warnings as errors). The fix is simple, add `#ifndef` around the defines so they are only defined if not already defined.