### PR TITLE
Move `extern "C"` below `#include`s in API header.

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -5,11 +5,6 @@
 #ifndef __ENET_ENET_H__
 #define __ENET_ENET_H__
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <stdlib.h>
 
 #ifdef _WIN32
@@ -22,6 +17,11 @@ extern "C"
 #include "enet/protocol.h"
 #include "enet/list.h"
 #include "enet/callbacks.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 #define ENET_VERSION_MAJOR 1
 #define ENET_VERSION_MINOR 3


### PR DESCRIPTION
Hello. This is a small change that helps in using ENet as a dependency in a Swift project.

Basically, the issue is that Swift does not support mixing C and C++ code when using interop, it has to use either C or C++, so if someone already has a C++ dependency in their project, Swift will try to import ENet as Objective-C++, but this will cause issues due to #includes.

This technically is a shortcoming of Swift, not specifically an issue with ENet, but the fix is very simple and from what I know shouldn't break anything for people using ENet from C/C++/other languages with interop.