### PR TITLE
packet.c: Fix UB when increasing the size of an unallocated packet

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -1,4 +1,4 @@
-/** 
+/**
  @file  packet.c
  @brief ENet packet management functions
 */
@@ -6,8 +6,8 @@
 #define ENET_BUILDING_LIB 1
 #include "enet/enet.h"
 
-/** @defgroup Packet ENet packet functions 
-    @{ 
+/** @defgroup Packet ENet packet functions
+    @{
 */
 
 /** Creates a packet that may be sent to a peer.
@@ -67,8 +67,8 @@ enet_packet_destroy (ENetPacket * packet)
     enet_free (packet);
 }
 
-/** Attempts to resize the data in the packet to length specified in the 
-    dataLength parameter 
+/** Attempts to resize the data in the packet to length specified in the
+    dataLength parameter
     @param packet packet to resize
     @param dataLength new size for the packet data
     @returns 0 on success, < 0 on failure
@@ -77,21 +77,24 @@ int
 enet_packet_resize (ENetPacket * packet, size_t dataLength)
 {
     enet_uint8 * newData;
-   
+
     if (dataLength <= packet -> dataLength || (packet -> flags & ENET_PACKET_FLAG_NO_ALLOCATE))
     {
-       packet -> dataLength = dataLength;
+      packet -> dataLength = dataLength;
 
-       return 0;
+      return 0;
     }
 
     newData = (enet_uint8 *) enet_malloc (dataLength);
     if (newData == NULL)
       return -1;
 
-    memcpy (newData, packet -> data, packet -> dataLength);
-    enet_free (packet -> data);
-    
+    if (packet -> data != NULL)
+    {
+      memcpy (newData, packet -> data, packet -> dataLength);
+      enet_free (packet -> data);
+    }
+
     packet -> data = newData;
     packet -> dataLength = dataLength;
 


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/string/byte/memcpy

> If either `dest` or `src` is an [invalid or null pointer](https://en.cppreference.com/w/cpp/language/pointer#Pointers), the behavior is undefined, even if `count` is zero.

https://en.cppreference.com/w/c/string/byte/memcpy

> The behavior is undefined if either `dest` or `src` is an invalid or null pointer.

---

I've also noticed a lot of trailing whitespace and odd (3-spaced) indentation in the current library code. Would you be interested in a pull request that fixes this?