### PR TITLE
Add ENET_SOCKOPT_TOS for IP_TOS (Type of Service)

### DIFF
--- a/include/enet/enet.h
+++ b/include/enet/enet.h
@@ -58,7 +58,8 @@ typedef enum _ENetSocketOption
    ENET_SOCKOPT_SNDTIMEO  = 7,
    ENET_SOCKOPT_ERROR     = 8,
    ENET_SOCKOPT_NODELAY   = 9,
-   ENET_SOCKOPT_TTL       = 10
+   ENET_SOCKOPT_TTL       = 10,
+   ENET_SOCKOPT_TOS       = 11
 } ENetSocketOption;
 
 typedef enum _ENetSocketShutdown

--- a/unix.c
+++ b/unix.c
@@ -352,6 +352,10 @@ enet_socket_set_option (ENetSocket socket, ENetSocketOption option, int value)
             result = setsockopt (socket, IPPROTO_IP, IP_TTL, (char *) & value, sizeof (int));
             break;
 
+        case ENET_SOCKOPT_TOS:
+            result = setsockopt (socket, IPPROTO_IP, IP_TOS, (char *) & value, sizeof (int));
+            break;
+
         default:
             break;
     }
@@ -373,6 +377,11 @@ enet_socket_get_option (ENetSocket socket, ENetSocketOption option, int * value)
         case ENET_SOCKOPT_TTL:
             len = sizeof (int);
             result = getsockopt (socket, IPPROTO_IP, IP_TTL, (char *) value, & len);
+            break;
+
+        case ENET_SOCKOPT_TOS:
+            len = sizeof (int);
+            result = getsockopt (socket, IPPROTO_IP, IP_TOS, (char *) value, & len);
             break;
 
         default:

--- a/win32.c
+++ b/win32.c
@@ -236,6 +236,10 @@ enet_socket_set_option (ENetSocket socket, ENetSocketOption option, int value)
             result = setsockopt (socket, IPPROTO_IP, IP_TTL, (char *) & value, sizeof (int));
             break;
 
+        case ENET_SOCKOPT_TOS:
+            result = setsockopt (socket, IPPROTO_IP, IP_TOS, (char *) & value, sizeof (int));
+            break;
+
         default:
             break;
     }
@@ -256,6 +260,11 @@ enet_socket_get_option (ENetSocket socket, ENetSocketOption option, int * value)
         case ENET_SOCKOPT_TTL:
             len = sizeof(int);
             result = getsockopt (socket, IPPROTO_IP, IP_TTL, (char *) value, & len);
+            break;
+
+        case ENET_SOCKOPT_TOS:
+            len = sizeof(int);
+            result = getsockopt (socket, IPPROTO_IP, IP_TOS, (char *) value, & len);
             break;
 
         default:


### PR DESCRIPTION
Even though the TOS socket option is deprecated on Windows, it can be still useful on Unix platforms.