### PR TITLE
add WIN32_LEAN_AND_MEAN and NOMINMAX definitions in win32.h

### DIFF
--- a/include/enet/win32.h
+++ b/include/enet/win32.h
@@ -1,4 +1,4 @@
-/** 
+/**
  @file  win32.h
  @brief ENet Win32 header
 */
@@ -21,6 +21,8 @@
 #endif
 
 #include <stdlib.h>
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <winsock2.h>
 
 typedef SOCKET ENetSocket;


### PR DESCRIPTION
Depending on the setup, NOMINMAX isn't defined and MIN and MAX are overriden.

This just fixes the macro problem.