### PR TITLE
Use offsetof to compute ENetProtocolHeader's sentTime offset

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -2,6 +2,7 @@
  @file  protocol.c
  @brief ENet protocol functions
 */
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #define ENET_BUILDING_LIB 1
@@ -1020,7 +1021,7 @@ enet_protocol_handle_incoming_commands (ENetHost * host, ENetEvent * event)
     enet_uint16 peerID, flags;
     enet_uint8 sessionID;
 
-    if (host -> receivedDataLength < (size_t) & ((ENetProtocolHeader *) 0) -> sentTime)
+    if (host -> receivedDataLength < offsetof(ENetProtocolHeader, sentTime))
       return 0;
 
     header = (ENetProtocolHeader *) host -> receivedData;
@@ -1030,7 +1031,7 @@ enet_protocol_handle_incoming_commands (ENetHost * host, ENetEvent * event)
     flags = peerID & ENET_PROTOCOL_HEADER_FLAG_MASK;
     peerID &= ~ (ENET_PROTOCOL_HEADER_FLAG_MASK | ENET_PROTOCOL_HEADER_SESSION_MASK);
 
-    headerSize = (flags & ENET_PROTOCOL_HEADER_FLAG_SENT_TIME ? sizeof (ENetProtocolHeader) : (size_t) & ((ENetProtocolHeader *) 0) -> sentTime);
+    headerSize = (flags & ENET_PROTOCOL_HEADER_FLAG_SENT_TIME ? sizeof (ENetProtocolHeader) : offsetof(ENetProtocolHeader, sentTime));
     if (host -> checksum != NULL)
       headerSize += sizeof (enet_uint32);
 
@@ -1682,7 +1683,7 @@ enet_protocol_send_outgoing_commands (ENetHost * host, ENetEvent * event, int ch
             host -> buffers -> dataLength = sizeof (ENetProtocolHeader);
         }
         else
-          host -> buffers -> dataLength = (size_t) & ((ENetProtocolHeader *) 0) -> sentTime;
+          host -> buffers -> dataLength = offsetof(ENetProtocolHeader, sentTime);
 
         shouldCompress = 0;
         if (host -> compressor.context != NULL && host -> compressor.compress != NULL)


### PR DESCRIPTION
The Zig compiler had issues with this code:

```
(size_t) & ((ENetProtocolHeader *) 0) -> sentTime
```

Zig was able to compile this code, but would crash at runtime from a null pointer dereference.

Replacing this expression with `offsetof` fixed the issue:

```
offsetof(ENetProtocolHeader, sentTime)
```

